### PR TITLE
Increase Windows MSVC stack size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# 64 bit MSVC
+[target.x86_64-pc-windows-msvc]
+rustflags = [
+    "-C", "link-arg=/STACK:2000000"
+]
+
+# 64 bit Mingw
+[target.x86_64-pc-windows-gnu]
+rustflags = [
+    "-C", "link-arg=-Wl,--stack,2000000"
+]


### PR DESCRIPTION
There is an issue in nestadia-wgpu on Windows, using the MSVC toolchain: "thread 'main' has overflowed its stack"

According to this [thread](https://users.rust-lang.org/t/stack-overflow-when-compiling-on-windows-10/50818), it seems the Windows stack is limited to 1MB on the main thread, instead of the usual 2MB.

The overflow was happening while running `let mut state = block_on(State::new(&window, emulator));`.

Bumping the stack size to 2MB using the cargo config file fixes this stack overflow issue.