### PR TITLE
Accurate sprite rendering

### DIFF
--- a/nestadia/src/cartridge/mapper_004.rs
+++ b/nestadia/src/cartridge/mapper_004.rs
@@ -118,11 +118,14 @@ impl Mapper for Mapper004 {
             0xA000..=0xBFFF => {
                 if (addr & 0x01) == 0 {
                     // Mirroring
-                    if let Mirroring::FourScreen = self.mirroring {
-                        self.mirroring = match data & 0x01 {
-                            0 => Mirroring::Vertical,
-                            1 => Mirroring::Horizontal,
-                            _ => unreachable!(),
+                    match self.mirroring {
+                        Mirroring::FourScreen => {}
+                        _ => {
+                            self.mirroring = match data & 0x01 {
+                                0 => Mirroring::Vertical,
+                                1 => Mirroring::Horizontal,
+                                _ => unreachable!(),
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
Still a WIP, code isn't clean yet.

I opened the PR so you could have a look at it and tell me what you think. The idea of the PR is to include de sprites in the rendering pipeline, instead of dumping them near then end. This fixed a bunch of graphics bug in multiple games.

Some remarks:
Sprite 0 is implemented "correctly", but now Mario freezes, probably because of a timing issue. I still put the old approximation in to temporarly fix this

I also implemented rendering masks.

Addresses https://github.com/zer0x64/nestadia/pull/56