### PR TITLE
Debugger improvements

### DIFF
--- a/nestadia-wgpu/Cargo.toml
+++ b/nestadia-wgpu/Cargo.toml
@@ -11,7 +11,7 @@ bitflags = "1.2.1"
 bytemuck = {version = "1.5.1", features = ["derive"]}
 futures = "0.3.15"
 native-dialog = "0.5.5"
-nestadia = { path = "../nestadia" }
+nestadia = { path = "../nestadia", features = ["debugger"] }
 structopt = "0.3.21"
 wgpu = "0.8.1"
 winit = "0.25.0"

--- a/nestadia-wgpu/src/debugger.rs
+++ b/nestadia-wgpu/src/debugger.rs
@@ -7,36 +7,51 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(no_version)]
+/// Nestadia debugger commands, inspired by GDB
 enum DebuggerOpt {
-    #[structopt(alias = "c", no_version)]
+    #[structopt(visible_alias = "c", no_version)]
+    /// Resume execution of the emulator
     Continue,
 
-    #[structopt(alias = "b", no_version)]
+    #[structopt(visible_alias = "b", no_version)]
+    /// Set breakpoint at the specified location
     Break {
         #[structopt(parse(try_from_str = parse_hex_addr))]
+        /// Address to break on. The breakpoint will be placed at the nearest instruction of the currently loaded bank
         addr: u16,
     },
 
-    #[structopt(no_version)]
-    Delete { index: Option<usize> },
+    #[structopt(visible_alias = "del", no_version)]
+    /// Remove a breakpoint with the specified index, or all breakpoints if no index is passed.
+    Delete {
+        /// Index of the breakpoint to remove.
+        index: Option<usize>,
+    },
 
-    #[structopt(alias = "s", no_version)]
+    #[structopt(visible_alias = "s", no_version)]
+    /// Execute one CPU instruction
     Step,
 
-    #[structopt(alias = "i", no_version)]
+    #[structopt(visible_alias = "i", no_version)]
+    /// Print various information
     Info(DebuggerInfoOpt),
 
-    #[structopt(alias = "disas", no_version)]
+    #[structopt(visible_alias = "disas", no_version)]
+    /// Print the disassembly from the currently loaded program banks.
     Disassemble {
         #[structopt(parse(try_from_str = parse_hex_addr))]
+        /// Reference address to search. If missing, the reference will be the current instruction
         search_addr: Option<u16>,
     },
 
-    #[structopt(alias = "hex", no_version)]
+    #[structopt(visible_alias = "x", no_version)]
+    /// Print an hex dump of the CPU memory
     Hexdump {
         #[structopt(parse(try_from_str = parse_hex_addr))]
+        /// Beginning of the range to print. Minimum is 0x0000
         start_addr: u16,
         #[structopt(parse(try_from_str = parse_hex_addr))]
+        /// End of the range to print. Maximum is 0xFFFF
         end_addr: u16,
     },
 }
@@ -44,9 +59,11 @@ enum DebuggerOpt {
 #[derive(Debug, StructOpt)]
 #[structopt(no_version)]
 enum DebuggerInfoOpt {
-    #[structopt(alias = "b", no_version)]
+    #[structopt(visible_alias = "b", no_version)]
+    /// Display the breakpoints currently set
     Break,
-    #[structopt(alias = "r", no_version)]
+    #[structopt(visible_alias = "r", no_version)]
+    /// Display registers, or a specific register if specified
     Reg { register: Option<String> },
 }
 
@@ -55,8 +72,10 @@ fn parse_hex_addr(src: &str) -> Result<u16, std::num::ParseIntError> {
     u16::from_str_radix(src, 16)
 }
 
+type Frame = [u8; 256 * 240];
+
 impl State {
-    pub fn debugger_prompt(&mut self) -> Option<[u8; 256 * 240]> {
+    pub fn debugger_prompt(&mut self) -> Option<Frame> {
         let mut frame = None;
 
         print!("debugger> ");
@@ -77,133 +96,149 @@ impl State {
                 let opt = DebuggerOpt::from_clap(&clap);
                 match opt {
                     DebuggerOpt::Continue => self.paused = false,
-                    DebuggerOpt::Break { addr } => {
-                        let disassembly = self.emulator.disassemble(0, 0);
-                        let closest_addr = disassembly
-                            .iter()
-                            .min_by_key(|&(_, x, _)| (x.wrapping_sub(addr)))
-                            .unwrap()
-                            .1;
-
-                        self.breakpoints.push(closest_addr);
-                        println!("Added breakpoint at {:#06x}", closest_addr);
-                    }
-                    DebuggerOpt::Delete { index } => {
-                        if let Some(index) = index {
-                            let removed = self.breakpoints.remove(index);
-                            println!("Removed breakpoint {}: {:#06x}", index, removed);
-                        } else {
-                            self.breakpoints.clear();
-                            println!("Cleared all breakpoints");
-                        }
-                    }
-                    DebuggerOpt::Step => {
-                        let current_pc = self.emulator.cpu().pc;
-                        while {
-                            if let Some(step_frame) = self.emulator.clock() {
-                                frame = Some(*step_frame);
-                            }
-                            self.emulator.cpu().cycles > 0 || self.emulator.cpu().pc == current_pc
-                        } {}
-                        println!("pc: {:#06x}", self.emulator.cpu().pc);
-                    }
+                    DebuggerOpt::Break { addr } => self.add_breakpoint(addr),
+                    DebuggerOpt::Delete { index } => self.remove_breakpoint(index),
+                    DebuggerOpt::Step => self.step(&mut frame),
                     DebuggerOpt::Info(info) => match info {
-                        DebuggerInfoOpt::Break => {
-                            for (index, addr) in self.breakpoints.iter().enumerate() {
-                                println!("Breakpoint {}: {:#06x}", index, addr);
-                            }
-                        }
-                        DebuggerInfoOpt::Reg { register } => {
-                            let cpu = self.emulator.cpu();
-                            if let Some(register) = register {
-                                match register.as_str() {
-                                    "a" => println!("a: {:#06x}", cpu.a),
-                                    "x" => println!("x: {:#06x}", cpu.x),
-                                    "y" => println!("y: {:#06x}", cpu.y),
-                                    "st" => println!("st: {:#06x}", cpu.st),
-                                    "pc" => println!("pc: {:#06x}", cpu.pc),
-                                    "status" => println!("status: {:#06x}", cpu.status_register),
-                                    reg => println!("Unknown register: {}", reg),
-                                }
-                            } else {
-                                println!(
-                                    " a: {:#06x}      x: {:#06x}      y: {:#06x}",
-                                    cpu.a, cpu.x, cpu.y
-                                );
-                                println!(
-                                    "st: {:#06x}     pc: {:#06x} status: {:#06x}",
-                                    cpu.st, cpu.pc, cpu.status_register
-                                );
-                            }
-                        }
+                        DebuggerInfoOpt::Break => self.print_breakpoints(),
+                        DebuggerInfoOpt::Reg { register } => self.print_registers(register),
                     },
-                    DebuggerOpt::Disassemble { search_addr } => {
-                        let cpu = self.emulator.cpu();
-                        let disassembly = self.emulator.disassemble(0, 0);
-
-                        let center_addr = if let Some(search_addr) = search_addr {
-                            search_addr
-                        } else {
-                            cpu.pc
-                        };
-
-                        for (prg_bank, addr, disas) in &disassembly {
-                            if (*addr as usize) > (center_addr as usize) - 20
-                                && (*addr as usize) < (center_addr as usize) + 20
-                            {
-                                let prefix = if (*addr as usize) == (cpu.pc as usize) {
-                                    ">"
-                                } else {
-                                    " "
-                                };
-
-                                let bank = if let Some(prg_bank) = prg_bank {
-                                    format!("{:#04x}:", prg_bank)
-                                } else {
-                                    String::from("    :")
-                                };
-
-                                println!("{} {}{:#06x}: {}", prefix, bank, addr, disas);
-                            }
-                        }
-                    }
+                    DebuggerOpt::Disassemble { search_addr } => self.disassemble(search_addr),
                     DebuggerOpt::Hexdump {
                         start_addr,
                         end_addr,
-                    } => {
-                        // Align start address to get 16 values
-                        let start_addr = start_addr - (start_addr & 0xf);
-                        let data = self.emulator.mem_dump(start_addr, end_addr);
-
-                        for (i, chunk) in data.chunks(16).enumerate() {
-                            let addr = start_addr + (16 * i as u16);
-
-                            let bytes = chunk
-                                .iter()
-                                .map(|c| format!("{:02x}", c))
-                                .collect::<Vec<_>>()
-                                .join(" ");
-
-                            let ascii = chunk
-                                .iter()
-                                .map(|num| {
-                                    if *num >= 32 && *num <= 126 {
-                                        (*num as char).to_string()
-                                    } else {
-                                        '.'.to_string()
-                                    }
-                                })
-                                .collect::<Vec<_>>()
-                                .join("");
-
-                            println!("{:#06x}: {:47} {}", addr, bytes, ascii);
-                        }
-                    }
+                    } => self.hexdump(start_addr, end_addr),
                 }
             }
             Err(e) => println!("{}", e.message),
         }
 
         frame
+    }
+
+    fn add_breakpoint(&mut self, addr: u16) {
+        let disassembly = self.emulator.disassemble(0, 0);
+        let closest_addr = disassembly
+            .iter()
+            .min_by_key(|&(_, x, _)| (x.wrapping_sub(addr)))
+            .unwrap()
+            .1;
+
+        self.breakpoints.push(closest_addr);
+        println!("Added breakpoint at {:#06x}", closest_addr);
+    }
+
+    fn remove_breakpoint(&mut self, index: Option<usize>) {
+        if let Some(index) = index {
+            let removed = self.breakpoints.remove(index);
+            println!("Removed breakpoint {}: {:#06x}", index, removed);
+        } else {
+            self.breakpoints.clear();
+            println!("Cleared all breakpoints");
+        }
+    }
+
+    fn step(&mut self, frame: &mut Option<Frame>) {
+        let current_pc = self.emulator.cpu().pc;
+        while {
+            if let Some(step_frame) = self.emulator.clock() {
+                *frame = Some(*step_frame);
+            }
+            self.emulator.cpu().cycles > 0 || self.emulator.cpu().pc == current_pc
+        } {}
+
+        self.disassemble(None);
+        self.print_registers(None);
+    }
+
+    fn print_breakpoints(&self) {
+        for (index, addr) in self.breakpoints.iter().enumerate() {
+            println!("Breakpoint {}: {:#06x}", index, addr);
+        }
+    }
+
+    fn print_registers(&self, register: Option<String>) {
+        let cpu = self.emulator.cpu();
+        if let Some(register) = register {
+            match register.as_str() {
+                "a" => println!("a: {:#06x}", cpu.a),
+                "x" => println!("x: {:#06x}", cpu.x),
+                "y" => println!("y: {:#06x}", cpu.y),
+                "st" => println!("st: {:#06x}", cpu.st),
+                "pc" => println!("pc: {:#06x}", cpu.pc),
+                "status" => println!("status: {:#06x}", cpu.status_register),
+                reg => println!("Unknown register: {}", reg),
+            }
+        } else {
+            println!(
+                " a: {:#06x}      x: {:#06x}      y: {:#06x}",
+                cpu.a, cpu.x, cpu.y
+            );
+            println!(
+                "st: {:#06x}     pc: {:#06x} status: {:#06x}",
+                cpu.st, cpu.pc, cpu.status_register
+            );
+        }
+    }
+
+    fn disassemble(&self, search_addr: Option<u16>) {
+        let cpu = self.emulator.cpu();
+        let disassembly = self.emulator.disassemble(0, 0);
+
+        let center_addr = if let Some(search_addr) = search_addr {
+            search_addr
+        } else {
+            cpu.pc
+        };
+
+        for (prg_bank, addr, disas) in &disassembly {
+            if (*addr as usize) > (center_addr as usize) - 20
+                && (*addr as usize) < (center_addr as usize) + 20
+            {
+                let prefix = if (*addr as usize) == (cpu.pc as usize) {
+                    ">"
+                } else {
+                    " "
+                };
+
+                let bank = if let Some(prg_bank) = prg_bank {
+                    format!("{:#04x}:", prg_bank)
+                } else {
+                    String::from("    :")
+                };
+
+                println!("{} {}{:#06x}: {}", prefix, bank, addr, disas);
+            }
+        }
+    }
+
+    fn hexdump(&mut self, start_addr: u16, end_addr: u16) {
+        // Align start address to get 16 values
+        let start_addr = start_addr - (start_addr & 0xf);
+        let data = self.emulator.mem_dump(start_addr, end_addr);
+
+        for (i, chunk) in data.chunks(16).enumerate() {
+            let addr = start_addr + (16 * i as u16);
+
+            let bytes = chunk
+                .iter()
+                .map(|c| format!("{:02x}", c))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            let ascii = chunk
+                .iter()
+                .map(|num| {
+                    if *num >= 32 && *num <= 126 {
+                        (*num as char).to_string()
+                    } else {
+                        '.'.to_string()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("");
+
+            println!("{:#06x}: {:47} {}", addr, bytes, ascii);
+        }
     }
 }

--- a/nestadia-wgpu/src/debugger.rs
+++ b/nestadia-wgpu/src/debugger.rs
@@ -1,0 +1,209 @@
+use crate::State;
+
+use std::io::{stdin, stdout, Write};
+
+use structopt::clap::AppSettings;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(no_version)]
+enum DebuggerOpt {
+    #[structopt(alias = "c", no_version)]
+    Continue,
+
+    #[structopt(alias = "b", no_version)]
+    Break {
+        #[structopt(parse(try_from_str = parse_hex_addr))]
+        addr: u16,
+    },
+
+    #[structopt(no_version)]
+    Delete { index: Option<usize> },
+
+    #[structopt(alias = "s", no_version)]
+    Step,
+
+    #[structopt(alias = "i", no_version)]
+    Info(DebuggerInfoOpt),
+
+    #[structopt(alias = "disas", no_version)]
+    Disassemble {
+        #[structopt(parse(try_from_str = parse_hex_addr))]
+        search_addr: Option<u16>,
+    },
+
+    #[structopt(alias = "hex", no_version)]
+    Hexdump {
+        #[structopt(parse(try_from_str = parse_hex_addr))]
+        start_addr: u16,
+        #[structopt(parse(try_from_str = parse_hex_addr))]
+        end_addr: u16,
+    },
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(no_version)]
+enum DebuggerInfoOpt {
+    #[structopt(alias = "b", no_version)]
+    Break,
+    #[structopt(alias = "r", no_version)]
+    Reg { register: Option<String> },
+}
+
+fn parse_hex_addr(src: &str) -> Result<u16, std::num::ParseIntError> {
+    let src = src.trim_start_matches("0x");
+    u16::from_str_radix(src, 16)
+}
+
+impl State {
+    pub fn debugger_prompt(&mut self) -> Option<[u8; 256 * 240]> {
+        let mut frame = None;
+
+        print!("debugger> ");
+        stdout().flush().unwrap();
+
+        let mut input = String::new();
+        stdin().read_line(&mut input).unwrap();
+
+        let tokens = input.split_ascii_whitespace();
+        let clap = DebuggerOpt::clap()
+            .global_setting(AppSettings::NoBinaryName)
+            .global_setting(AppSettings::DisableVersion)
+            .global_setting(AppSettings::VersionlessSubcommands)
+            .get_matches_from_safe(tokens);
+
+        match clap {
+            Ok(clap) => {
+                let opt = DebuggerOpt::from_clap(&clap);
+                match opt {
+                    DebuggerOpt::Continue => self.paused = false,
+                    DebuggerOpt::Break { addr } => {
+                        let disassembly = self.emulator.disassemble(0, 0);
+                        let closest_addr = disassembly
+                            .iter()
+                            .min_by_key(|&(_, x, _)| (x.wrapping_sub(addr)))
+                            .unwrap()
+                            .1;
+
+                        self.breakpoints.push(closest_addr);
+                        println!("Added breakpoint at {:#06x}", closest_addr);
+                    }
+                    DebuggerOpt::Delete { index } => {
+                        if let Some(index) = index {
+                            let removed = self.breakpoints.remove(index);
+                            println!("Removed breakpoint {}: {:#06x}", index, removed);
+                        } else {
+                            self.breakpoints.clear();
+                            println!("Cleared all breakpoints");
+                        }
+                    }
+                    DebuggerOpt::Step => {
+                        let current_pc = self.emulator.cpu().pc;
+                        while {
+                            if let Some(step_frame) = self.emulator.clock() {
+                                frame = Some(*step_frame);
+                            }
+                            self.emulator.cpu().cycles > 0 || self.emulator.cpu().pc == current_pc
+                        } {}
+                        println!("pc: {:#06x}", self.emulator.cpu().pc);
+                    }
+                    DebuggerOpt::Info(info) => match info {
+                        DebuggerInfoOpt::Break => {
+                            for (index, addr) in self.breakpoints.iter().enumerate() {
+                                println!("Breakpoint {}: {:#06x}", index, addr);
+                            }
+                        }
+                        DebuggerInfoOpt::Reg { register } => {
+                            let cpu = self.emulator.cpu();
+                            if let Some(register) = register {
+                                match register.as_str() {
+                                    "a" => println!("a: {:#06x}", cpu.a),
+                                    "x" => println!("x: {:#06x}", cpu.x),
+                                    "y" => println!("y: {:#06x}", cpu.y),
+                                    "st" => println!("st: {:#06x}", cpu.st),
+                                    "pc" => println!("pc: {:#06x}", cpu.pc),
+                                    "status" => println!("status: {:#06x}", cpu.status_register),
+                                    reg => println!("Unknown register: {}", reg),
+                                }
+                            } else {
+                                println!(
+                                    " a: {:#06x}      x: {:#06x}      y: {:#06x}",
+                                    cpu.a, cpu.x, cpu.y
+                                );
+                                println!(
+                                    "st: {:#06x}     pc: {:#06x} status: {:#06x}",
+                                    cpu.st, cpu.pc, cpu.status_register
+                                );
+                            }
+                        }
+                    },
+                    DebuggerOpt::Disassemble { search_addr } => {
+                        let cpu = self.emulator.cpu();
+                        let disassembly = self.emulator.disassemble(0, 0);
+
+                        let center_addr = if let Some(search_addr) = search_addr {
+                            search_addr
+                        } else {
+                            cpu.pc
+                        };
+
+                        for (prg_bank, addr, disas) in &disassembly {
+                            if (*addr as usize) > (center_addr as usize) - 20
+                                && (*addr as usize) < (center_addr as usize) + 20
+                            {
+                                let prefix = if (*addr as usize) == (cpu.pc as usize) {
+                                    ">"
+                                } else {
+                                    " "
+                                };
+
+                                let bank = if let Some(prg_bank) = prg_bank {
+                                    format!("{:#04x}:", prg_bank)
+                                } else {
+                                    String::from("    :")
+                                };
+
+                                println!("{} {}{:#06x}: {}", prefix, bank, addr, disas);
+                            }
+                        }
+                    }
+                    DebuggerOpt::Hexdump {
+                        start_addr,
+                        end_addr,
+                    } => {
+                        // Align start address to get 16 values
+                        let start_addr = start_addr - (start_addr & 0xf);
+                        let data = self.emulator.mem_dump(start_addr, end_addr);
+
+                        for (i, chunk) in data.chunks(16).enumerate() {
+                            let addr = start_addr + (16 * i as u16);
+
+                            let bytes = chunk
+                                .iter()
+                                .map(|c| format!("{:02x}", c))
+                                .collect::<Vec<_>>()
+                                .join(" ");
+
+                            let ascii = chunk
+                                .iter()
+                                .map(|num| {
+                                    if *num >= 32 && *num <= 126 {
+                                        (*num as char).to_string()
+                                    } else {
+                                        '.'.to_string()
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .join("");
+
+                            println!("{:#06x}: {:47} {}", addr, bytes, ascii);
+                        }
+                    }
+                }
+            }
+            Err(e) => println!("{}", e.message),
+        }
+
+        frame
+    }
+}

--- a/nestadia-wgpu/src/main.rs
+++ b/nestadia-wgpu/src/main.rs
@@ -25,6 +25,9 @@ use structopt::StructOpt;
 struct Opt {
     #[structopt(parse(from_os_str))]
     rom: Option<PathBuf>,
+
+    #[structopt(short = "p", long)]
+    start_paused: bool,
 }
 
 mod debugger;
@@ -533,6 +536,7 @@ impl State {
 
     fn pause(&mut self) {
         self.paused = true;
+        println!("Emulator is paused");
     }
 }
 
@@ -578,6 +582,9 @@ fn main() {
 
     // Wait until WGPU is ready
     let mut state = block_on(State::new(&window, emulator));
+    if opt.start_paused {
+        state.pause();
+    }
 
     // Handle window events
     event_loop.run(move |event, _, control_flow| match event {
@@ -646,7 +653,6 @@ fn main() {
                         ..
                     } => {
                         state.pause();
-                        println!("Emulator is paused");
                     }
                     _ => {}
                 }

--- a/nestadia/src/cartridge/mapper_000.rs
+++ b/nestadia/src/cartridge/mapper_000.rs
@@ -42,4 +42,13 @@ impl Mapper for Mapper000 {
     fn get_sram(&self) -> Option<&[u8]> {
         None
     }
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        match addr {
+            0x8000..=0xBFFF => Some(0),
+            0xC000..=0xFFFF => Some(1),
+            _ => None,
+        }
+    }
 }

--- a/nestadia/src/cartridge/mapper_001.rs
+++ b/nestadia/src/cartridge/mapper_001.rs
@@ -67,7 +67,10 @@ impl Mapper for Mapper001 {
                             (self.prg_bank_selector_16_hi as usize) * 0x4000
                                 + (addr & 0x3FFF) as usize,
                         ),
-                        _ => unreachable!(),
+                        _ => {
+                            log::warn!("Attempted to read address w/o known mapping {:#06x}", addr);
+                            CartridgeReadTarget::PrgRom(0)
+                        }
                     }
                 } else {
                     // 32K PRG mode
@@ -178,5 +181,25 @@ impl Mapper for Mapper001 {
 
     fn get_sram(&self) -> Option<&[u8]> {
         Some(&self.ram_data)
+    }
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        match addr {
+            0x0000..=0x7FFF => None,
+            _ => {
+                if (self.control_register & PRG_MODE_MASK) > 1 {
+                    // 16K PRG mode
+                    match addr {
+                        0x8000..=0xBFFF => Some(self.prg_bank_selector_16_lo),
+                        0xC000..=0xFFFF => Some(self.prg_bank_selector_16_hi),
+                        _ => None,
+                    }
+                } else {
+                    // 32K PRG mode
+                    Some(self.prg_bank_selector_32)
+                }
+            }
+        }
     }
 }

--- a/nestadia/src/cartridge/mapper_002.rs
+++ b/nestadia/src/cartridge/mapper_002.rs
@@ -47,4 +47,13 @@ impl Mapper for Mapper002 {
     fn get_sram(&self) -> Option<&[u8]> {
         None
     }
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        match addr {
+            0x8000..=0xBFFF => Some(self.prg_bank_selector),
+            0xC000..=0xFFFF => Some(self.prg_banks - 1),
+            _ => None,
+        }
+    }
 }

--- a/nestadia/src/cartridge/mapper_003.rs
+++ b/nestadia/src/cartridge/mapper_003.rs
@@ -42,4 +42,13 @@ impl Mapper for Mapper003 {
     fn get_sram(&self) -> Option<&[u8]> {
         None
     }
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        match addr {
+            0x8000..=0xBFFF => Some(0),
+            0xC000..=0xFFFF => Some(1),
+            _ => None,
+        }
+    }
 }

--- a/nestadia/src/cartridge/mapper_004.rs
+++ b/nestadia/src/cartridge/mapper_004.rs
@@ -223,4 +223,16 @@ impl Mapper for Mapper004 {
     fn get_sram(&self) -> Option<&[u8]> {
         Some(&self.ram_data)
     }
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        match addr {
+            0x0000..=0x7FFF => None,
+            // The bank selector select 8KB banks, so divide by 2 to get 16KB bank
+            0x8000..=0x9FFF => Some(self.prg_bank_selector[0] / 2),
+            0xA000..=0xBFFF => Some(self.prg_bank_selector[1] / 2),
+            0xC000..=0xDFFF => Some(self.prg_bank_selector[2] / 2),
+            0xE000..=0xFFFF => Some(self.prg_bank_selector[3] / 2),
+        }
+    }
 }

--- a/nestadia/src/cartridge/mapper_066.rs
+++ b/nestadia/src/cartridge/mapper_066.rs
@@ -43,4 +43,12 @@ impl Mapper for Mapper066 {
     fn get_sram(&self) -> Option<&[u8]> {
         None
     }
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        match addr {
+            0x8000..=0xFFFF => Some(self.prg_bank_selector),
+            _ => None,
+        }
+    }
 }

--- a/nestadia/src/cartridge/mod.rs
+++ b/nestadia/src/cartridge/mod.rs
@@ -13,11 +13,11 @@ use core::convert::TryFrom as _;
 
 use self::ines_header::{Flags6, INesHeader};
 use self::mapper_000::Mapper000;
+use self::mapper_001::Mapper001;
 use self::mapper_002::Mapper002;
 use self::mapper_003::Mapper003;
 use self::mapper_004::Mapper004;
 use self::mapper_066::Mapper066;
-use crate::cartridge::mapper_001::Mapper001;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Mirroring {
@@ -59,6 +59,9 @@ trait Mapper: Send + Sync {
     }
     fn irq_clear(&mut self) {}
     fn irq_scanline(&mut self) {}
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8>;
 }
 
 pub struct Cartridge {
@@ -195,13 +198,7 @@ impl Cartridge {
     }
 
     #[cfg(feature = "debugger")]
-    pub fn disassemble(&self) -> Vec<(u16, alloc::string::String)> {
-        let mut disas1 = crate::cpu::disassembler::disassemble(&self.prg_memory, 0x4000);
-        let disas2 = crate::cpu::disassembler::disassemble(&self.prg_memory, 0x8000);
-        let disas3 = crate::cpu::disassembler::disassemble(&self.prg_memory, 0xc000);
-
-        disas1.extend(disas2);
-        disas1.extend(disas3);
-        disas1
+    pub fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        self.mapper.get_prg_bank(addr)
     }
 }

--- a/nestadia/src/cpu/mod.rs
+++ b/nestadia/src/cpu/mod.rs
@@ -1521,6 +1521,11 @@ impl Cpu {
 
         self.pc = result;
     }
+
+    #[cfg(feature = "debugger")]
+    pub fn mem_dump(&mut self, bus: &mut CpuBus<'_>, addr: u16) -> u8 {
+        bus.read(addr)
+    }
 }
 
 impl CpuBus<'_> {

--- a/nestadia/src/lib.rs
+++ b/nestadia/src/lib.rs
@@ -124,8 +124,20 @@ impl Emulator {
         &self,
         start: u16,
         end: u16,
-    ) -> alloc::vec::Vec<(u16, alloc::string::String)> {
-        self.cartridge.disassemble()
+    ) -> alloc::vec::Vec<(Option<u8>, u16, alloc::string::String)> {
+        crate::cpu::disassembler::disassemble(&self.cartridge, 0x4020)
+    }
+
+    #[cfg(feature = "debugger")]
+    pub fn mem_dump(&mut self, start: u16, end: u16) -> alloc::vec::Vec<u8> {
+        let mut data = alloc::vec::Vec::new();
+
+        for addr in start..=end {
+            let mut bus = borrow_cpu_bus!(self);
+            data.push(self.cpu.mem_dump(&mut bus, addr));
+        }
+
+        data
     }
 
     #[cfg(feature = "debugger")]


### PR DESCRIPTION
Implemented a GDB-style debugger at the command line for the wgpu app. When the app is paused (by pressing P), the debugger prompts appears in the console.

Fixed the disassembly by reading the only loaded banks instead of the whole ROM, using the cartridge read. Also added a hexdump to print raw data from the whole CPU address space.