### PR TITLE
Implemented Mapper 007

### DIFF
--- a/nestadia/src/cartridge/mapper_007.rs
+++ b/nestadia/src/cartridge/mapper_007.rs
@@ -1,0 +1,58 @@
+use super::{CartridgeReadTarget, Mapper, Mirroring};
+
+pub struct Mapper007 {
+    prg_bank_selector: u8,
+    mirroring: Mirroring,
+}
+
+impl Mapper007 {
+    pub fn new() -> Self {
+        Self {
+            prg_bank_selector: 0,
+            mirroring: Mirroring::OneScreenUpper,
+        }
+    }
+}
+
+impl Mapper for Mapper007 {
+    fn cpu_map_read(&self, addr: u16) -> CartridgeReadTarget {
+        let addr = (addr & 0x7fff) as usize;
+        CartridgeReadTarget::PrgRom(addr + (self.prg_bank_selector as usize) * 0x8000)
+    }
+
+    fn cpu_map_write(&mut self, addr: u16, data: u8) {
+        if addr & 0x8000 == 0x8000 {
+            self.prg_bank_selector = data & 0b111;
+
+            self.mirroring = if data & 0x10 == 0x10 {
+                Mirroring::OneScreenUpper
+            } else {
+                Mirroring::OneScreenLower
+            };
+        };
+    }
+
+    fn ppu_map_read(&mut self, addr: u16) -> usize {
+        (addr & 0x1fff) as usize
+    }
+
+    fn ppu_map_write(&self, addr: u16) -> Option<usize> {
+        Some((addr & 0x1fff) as usize)
+    }
+
+    fn mirroring(&self) -> Mirroring {
+        self.mirroring
+    }
+
+    fn get_sram(&self) -> Option<&[u8]> {
+        None
+    }
+
+    #[cfg(feature = "debugger")]
+    fn get_prg_bank(&self, addr: u16) -> Option<u8> {
+        match addr {
+            0x8000..=0xFFFF => Some(self.prg_bank_selector),
+            _ => None,
+        }
+    }
+}

--- a/nestadia/src/cartridge/mod.rs
+++ b/nestadia/src/cartridge/mod.rs
@@ -4,6 +4,7 @@ mod mapper_001;
 mod mapper_002;
 mod mapper_003;
 mod mapper_004;
+mod mapper_007;
 mod mapper_066;
 
 use alloc::boxed::Box;
@@ -17,6 +18,7 @@ use self::mapper_001::Mapper001;
 use self::mapper_002::Mapper002;
 use self::mapper_003::Mapper003;
 use self::mapper_004::Mapper004;
+use self::mapper_007::Mapper007;
 use self::mapper_066::Mapper066;
 
 #[derive(Debug, Clone, Copy)]
@@ -93,6 +95,7 @@ impl Cartridge {
             2 => Box::new(Mapper002::new(header.prg_size, mirroring)),
             3 => Box::new(Mapper003::new(header.prg_size, mirroring)),
             4 => Box::new(Mapper004::new(header.prg_size, mirroring)),
+            7 => Box::new(Mapper007::new()),
             66 => Box::new(Mapper066::new(mirroring)),
             _ => return Err(RomParserError::MapperNotImplemented),
         };


### PR DESCRIPTION
Implements Mapper 007, used notably for Battletoads. The game freezes, as expected, but the mapper seems fine.