### PR TITLE
Implementing Color Emphasis

### DIFF
--- a/nestadia-libretro/src/lib.rs
+++ b/nestadia-libretro/src/lib.rs
@@ -123,11 +123,16 @@ impl Core for State {
     }
 
     fn on_run(&mut self, handle: &mut RuntimeHandle) {
+        let mask_reg;
+
         let emulator = match &mut self.emulator {
             None => {
                 return;
             }
-            Some(emulator) => emulator,
+            Some(emulator) => { 
+                mask_reg = emulator.get_ppu_mask_reg();
+                emulator
+            },
         };
 
         let frame = loop {
@@ -137,7 +142,7 @@ impl Core for State {
         };
 
         let mut current_frame = [0u8; NUM_PIXELS * 4];
-        nestadia::frame_to_argb(&frame, &mut current_frame);
+        Emulator::frame_to_argb(mask_reg, &frame, &mut current_frame);
 
         handle.upload_video_frame(&current_frame);
         handle.upload_audio_frame(&MOCK_AUDIO);

--- a/nestadia-libretro/src/lib.rs
+++ b/nestadia-libretro/src/lib.rs
@@ -129,10 +129,10 @@ impl Core for State {
             None => {
                 return;
             }
-            Some(emulator) => { 
+            Some(emulator) => {
                 mask_reg = emulator.get_ppu_mask_reg();
                 emulator
-            },
+            }
         };
 
         let frame = loop {

--- a/nestadia-libretro/src/lib.rs
+++ b/nestadia-libretro/src/lib.rs
@@ -142,7 +142,7 @@ impl Core for State {
         };
 
         let mut current_frame = [0u8; NUM_PIXELS * 4];
-        Emulator::frame_to_argb(mask_reg, &frame, &mut current_frame);
+        nestadia::frame_to_argb(mask_reg, &frame, &mut current_frame);
 
         handle.upload_video_frame(&current_frame);
         handle.upload_audio_frame(&MOCK_AUDIO);

--- a/nestadia-wasm/src/main.rs
+++ b/nestadia-wasm/src/main.rs
@@ -177,7 +177,7 @@ impl Component for EmulatorComponent {
                 // Convert to RGBA
                 let mut rgba_frame = [0u8; 256 * 240 * 4];
 
-                Emulator::frame_to_rgba(mask_reg, &frame, &mut rgba_frame);
+                nestadia::frame_to_rgba(mask_reg, &frame, &mut rgba_frame);
 
                 // Draw image data to the canvas
                 let image_data =

--- a/nestadia-wasm/src/main.rs
+++ b/nestadia-wasm/src/main.rs
@@ -152,6 +152,8 @@ impl Component for EmulatorComponent {
     }
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        let mask_reg = self.emulator.get_ppu_mask_reg();
+
         match msg {
             EmulatorMsg::RenderFrame => {
                 // Run until there's a frame
@@ -175,7 +177,7 @@ impl Component for EmulatorComponent {
                 // Convert to RGBA
                 let mut rgba_frame = [0u8; 256 * 240 * 4];
 
-                nestadia::frame_to_rgba(&frame, &mut rgba_frame);
+                Emulator::frame_to_rgba(mask_reg, &frame, &mut rgba_frame);
 
                 // Draw image data to the canvas
                 let image_data =

--- a/nestadia-wgpu/src/main.rs
+++ b/nestadia-wgpu/src/main.rs
@@ -416,7 +416,7 @@ impl State {
 
             if let Some(frame) = frame {
                 let mut current_frame = [0u8; NUM_PIXELS * 4];
-                Emulator::frame_to_rgba(mask_reg, &frame, &mut current_frame);
+                nestadia::frame_to_rgba(mask_reg, &frame, &mut current_frame);
 
                 // Update texture
                 let texture_size = wgpu::Extent3d {
@@ -455,7 +455,7 @@ impl State {
 
             if let Some(frame) = frame {
                 let mut current_frame = [0u8; NUM_PIXELS * 4];
-                Emulator::frame_to_rgba(mask_reg, &frame, &mut current_frame);
+                nestadia::frame_to_rgba(mask_reg, &frame, &mut current_frame);
 
                 // Update texture
                 let texture_size = wgpu::Extent3d {

--- a/nestadia-wgpu/src/main.rs
+++ b/nestadia-wgpu/src/main.rs
@@ -409,12 +409,14 @@ impl State {
 
     /// Update the game state
     fn update(&mut self) {
+        let mask_reg = self.emulator.get_ppu_mask_reg();
+
         if self.paused {
             let frame = self.debugger_prompt();
 
             if let Some(frame) = frame {
                 let mut current_frame = [0u8; NUM_PIXELS * 4];
-                nestadia::frame_to_rgba(&frame, &mut current_frame);
+                Emulator::frame_to_rgba(mask_reg, &frame, &mut current_frame);
 
                 // Update texture
                 let texture_size = wgpu::Extent3d {
@@ -453,7 +455,7 @@ impl State {
 
             if let Some(frame) = frame {
                 let mut current_frame = [0u8; NUM_PIXELS * 4];
-                nestadia::frame_to_rgba(&frame, &mut current_frame);
+                Emulator::frame_to_rgba(mask_reg, &frame, &mut current_frame);
 
                 // Update texture
                 let texture_size = wgpu::Extent3d {

--- a/nestadia/src/lib.rs
+++ b/nestadia/src/lib.rs
@@ -147,47 +147,47 @@ impl Emulator {
     pub fn cpu(&self) -> &Cpu {
         &self.cpu
     }
+}
 
-    pub fn frame_to_rgb(mask_reg: MaskReg, frame: &PpuFrame, output: &mut [u8; 256 * 240 * 3]) {
-        let empasized_palette = &mut RGB_PALETTE.clone();
-        apply_emphasis(mask_reg, empasized_palette);
+pub fn frame_to_rgb(mask_reg: MaskReg, frame: &PpuFrame, output: &mut [u8; 256 * 240 * 3]) {
+    let empasized_palette = &mut RGB_PALETTE.clone();
+    apply_emphasis(mask_reg, empasized_palette);
 
-        for i in 0..frame.len() {
-            let f = empasized_palette[(frame[i] & 0x3f) as usize];
-            output[i * 3] = f[0]; // R
-            output[i * 3 + 1] = f[1]; // G
-            output[i * 3 + 2] = f[2]; // B
-        }
+    for i in 0..frame.len() {
+        let f = empasized_palette[(frame[i] & 0x3f) as usize];
+        output[i * 3] = f[0]; // R
+        output[i * 3 + 1] = f[1]; // G
+        output[i * 3 + 2] = f[2]; // B
     }
+}
 
-    pub fn frame_to_rgba(mask_reg: MaskReg, frame: &PpuFrame, output: &mut [u8; 256 * 240 * 4]) {
-        let empasized_palette = &mut RGB_PALETTE.clone();
-        apply_emphasis(mask_reg, empasized_palette);
+pub fn frame_to_rgba(mask_reg: MaskReg, frame: &PpuFrame, output: &mut [u8; 256 * 240 * 4]) {
+    let empasized_palette = &mut RGB_PALETTE.clone();
+    apply_emphasis(mask_reg, empasized_palette);
 
-        for i in 0..frame.len() {
-            let f = empasized_palette[(frame[i] & 0x3f) as usize];
-            output[i * 4] = f[0]; // R
-            output[i * 4 + 1] = f[1]; // G
-            output[i * 4 + 2] = f[2]; // B
+    for i in 0..frame.len() {
+        let f = empasized_palette[(frame[i] & 0x3f) as usize];
+        output[i * 4] = f[0]; // R
+        output[i * 4 + 1] = f[1]; // G
+        output[i * 4 + 2] = f[2]; // B
 
-            // Alpha is always 0xff because it's opaque
-            output[i * 4 + 3] = 0xff; // A
-        }
+        // Alpha is always 0xff because it's opaque
+        output[i * 4 + 3] = 0xff; // A
     }
+}
 
-    pub fn frame_to_argb(mask_reg: MaskReg, frame: &PpuFrame, output: &mut [u8; 256 * 240 * 4]) {
-        let empasized_palette = &mut RGB_PALETTE.clone();
-        apply_emphasis(mask_reg, empasized_palette);
+pub fn frame_to_argb(mask_reg: MaskReg, frame: &PpuFrame, output: &mut [u8; 256 * 240 * 4]) {
+    let empasized_palette = &mut RGB_PALETTE.clone();
+    apply_emphasis(mask_reg, empasized_palette);
 
-        for i in 0..frame.len() {
-            let f = empasized_palette[(frame[i] & 0x3f) as usize];
-            output[i * 4] = f[2]; // B
-            output[i * 4 + 1] = f[1]; // G
-            output[i * 4 + 2] = f[0]; // R
+    for i in 0..frame.len() {
+        let f = empasized_palette[(frame[i] & 0x3f) as usize];
+        output[i * 4] = f[2]; // B
+        output[i * 4 + 1] = f[1]; // G
+        output[i * 4 + 2] = f[0]; // R
 
-            // Alpha is always 0xff because it's opaque
-            output[i * 4 + 3] = 0xff; // A
-        }
+        // Alpha is always 0xff because it's opaque
+        output[i * 4 + 3] = 0xff; // A
     }
 }
 

--- a/nestadia/src/ppu/mod.rs
+++ b/nestadia/src/ppu/mod.rs
@@ -31,7 +31,7 @@ pub struct Ppu {
 
     // Registers
     ctrl_reg: registers::ControlReg,
-    mask_reg: registers::MaskReg,
+    pub mask_reg: registers::MaskReg,
     status_reg: registers::StatusReg,
     oam_addr_reg: u8,
     vram_addr: registers::VramAddr,


### PR DESCRIPTION
N.B.: The tinting is _kind of_ a placeholder because we handle the colors entirely in RGB instead of the NES's composite encoding. This makes the colors less authentic, but makes it much easier to work with. It might need to be reworked in the future depending on our needs.